### PR TITLE
Add support for nested array search in buildResult

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flrfinance/strapi-plugin-fuzzy-search",
-  "version": "0.0.0-development",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@flrfinance/strapi-plugin-fuzzy-search",
-      "version": "0.0.0-development",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "fuzzysort": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flrfinance/strapi-plugin-fuzzy-search",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Register a weighted fuzzy search endpoint for Strapi Headless CMS you can add your content types to in no time.",
   "strapi": {
     "displayName": "Fuzzy Search",

--- a/server/utils/__tests__/buildResult.test.ts
+++ b/server/utils/__tests__/buildResult.test.ts
@@ -61,5 +61,9 @@ describe('buildResult', () => {
     console.dir(result, { depth: null });
 
     expect(result.fuzzysortResults.length).toBe(1);
+
+    expect(result.fuzzysortResults[0]["obj"]["name"]).toBe("ququmber");
+
+    expect(result.fuzzysortResults[0]["obj"]["artists"][0]["Name"]).toBe("John Wick");
   });
 });

--- a/server/utils/__tests__/buildResult.test.ts
+++ b/server/utils/__tests__/buildResult.test.ts
@@ -19,8 +19,8 @@ describe('buildResult', () => {
       keys: [
         { name: 'name', weight: 100 },
         { name: 'play_type.title', weight: 100 },
-        { name: 'artists.Name', weight: 100 },
         { name: 'artists', weight: 100 },
+        { name: 'artists.Name', weight: 100 },
       ],
     },
     plays: [
@@ -38,6 +38,7 @@ describe('buildResult', () => {
             id: 1,
             Name: 'John Wick',
             description: 'yeah, that one',
+            somethingsElse : "something else",
             createdAt: '2023-04-05T15:03:15.660Z',
             updatedAt: '2023-04-05T17:01:17.867Z',
             publishedAt: '2023-04-05T15:03:21.793Z',
@@ -58,12 +59,23 @@ describe('buildResult', () => {
 
   test('can search nested array', () => {
     const result = buildResult({ model, keys, query });
-    console.dir(result, { depth: null });
 
     expect(result.fuzzysortResults.length).toBe(1);
 
-    expect(result.fuzzysortResults[0]["obj"]["name"]).toBe("ququmber");
+    expect(result.fuzzysortResults[0]['obj']['name']).toBe('ququmber');
 
-    expect(result.fuzzysortResults[0]["obj"]["artists"][0]["Name"]).toBe("John Wick");
+    expect(result.fuzzysortResults[0]['obj']['artists'][0]['Name']).toBe(
+      'John Wick'
+    );
+  });
+
+  test("search nested array, don't search not included fields", () => {
+    const result = buildResult({
+      model,
+      keys,
+      query : "somethings",
+    });
+
+    expect(result.fuzzysortResults.length).toBe(0);
   });
 });

--- a/server/utils/__tests__/buildResult.test.ts
+++ b/server/utils/__tests__/buildResult.test.ts
@@ -1,0 +1,65 @@
+import buildResult from '../buildResult';
+
+describe('buildResult', () => {
+  const model = {
+    uid: 'api::play.play',
+    pluralName: 'plays',
+    modelName: 'play',
+    schemaInfo: {
+      singularName: 'play',
+      pluralName: 'plays',
+      displayName: 'Play',
+      description: '',
+    },
+    transliterate: true,
+    fuzzysortOptions: {
+      characterLimit: 300,
+      threshold: -600,
+      limit: 10,
+      keys: [
+        { name: 'name', weight: 100 },
+        { name: 'play_type.title', weight: 100 },
+        { name: 'artists.Name', weight: 100 },
+        { name: 'artists', weight: 100 },
+      ],
+    },
+    plays: [
+      {
+        id: 1,
+        name: 'ququmber',
+        spotify_link: null,
+        createdAt: '2023-06-07T12:31:55.550Z',
+        updatedAt: '2023-06-12T13:46:41.429Z',
+        publishedAt: '2023-06-12T13:46:41.424Z',
+        play_type: null,
+        image: null,
+        artists: [
+          {
+            id: 1,
+            Name: 'John Wick',
+            description: 'yeah, that one',
+            createdAt: '2023-04-05T15:03:15.660Z',
+            updatedAt: '2023-04-05T17:01:17.867Z',
+            publishedAt: '2023-04-05T15:03:21.793Z',
+          },
+        ],
+      },
+    ],
+  } as any;
+
+  const keys = ['name', 'play_type.title', 'artists.Name', 'artists'];
+  const query = 'John';
+
+  test('can search by name', () => {
+    const result = buildResult({ model, keys, query: 'ququ' });
+
+    expect(result.fuzzysortResults.length).toBe(1);
+  });
+
+  test('can search nested array', () => {
+    const result = buildResult({ model, keys, query });
+    console.dir(result, { depth: null });
+
+    expect(result.fuzzysortResults.length).toBe(1);
+  });
+});

--- a/server/utils/__tests__/isJSON.test.ts
+++ b/server/utils/__tests__/isJSON.test.ts
@@ -1,0 +1,11 @@
+import isJSON from '../isJSON';
+
+describe('isJSON', () => {
+  test('can detect json', () => {
+    expect(isJSON('{"foo": "bar"}')).toBe(true);
+  });
+
+  test('can detect non-json', () => {
+    expect(isJSON('{"foo": "bar"')).toBe(false);
+  });
+});

--- a/server/utils/__tests__/isJSON.test.ts
+++ b/server/utils/__tests__/isJSON.test.ts
@@ -8,4 +8,20 @@ describe('isJSON', () => {
   test('can detect non-json', () => {
     expect(isJSON('{"foo": "bar"')).toBe(false);
   });
+
+  test('string is not json', () => {
+    expect(isJSON('foo')).toBe(false);
+  });
+
+  test('undefined is not json', () => {
+    expect(isJSON(undefined)).toBe(false);
+  });
+
+  test('null is not json', () => {
+    expect(isJSON(null)).toBe(false);
+  });
+
+  test('number is not json', () => {
+    expect(isJSON(1)).toBe(false);
+  });
 });

--- a/server/utils/__tests__/isJSON.test.ts
+++ b/server/utils/__tests__/isJSON.test.ts
@@ -1,27 +1,39 @@
-import isJSON from '../isJSON';
+import { isJson, tryGetJson } from '../isJSON';
 
 describe('isJSON', () => {
   test('can detect json', () => {
-    expect(isJSON('{"foo": "bar"}')).toBe(true);
+    expect(isJson('{"foo": "bar"}')).toBe(true);
   });
 
   test('can detect non-json', () => {
-    expect(isJSON('{"foo": "bar"')).toBe(false);
+    expect(isJson('{"foo": "bar"')).toBe(false);
   });
 
   test('string is not json', () => {
-    expect(isJSON('foo')).toBe(false);
+    expect(isJson('foo')).toBe(false);
   });
 
   test('undefined is not json', () => {
-    expect(isJSON(undefined)).toBe(false);
+    expect(isJson(undefined)).toBe(false);
   });
 
   test('null is not json', () => {
-    expect(isJSON(null)).toBe(false);
+    expect(isJson(null)).toBe(false);
   });
 
   test('number is not json', () => {
-    expect(isJSON(1)).toBe(false);
+    expect(isJson(1)).toBe(false);
   });
+
+  test("object is not json", () => {
+    expect(isJson({o : 1})).toBe(false);
+  })
+
+  test('try get json', () => {
+    expect(tryGetJson('{"foo": "bar"}')).toEqual({ foo: 'bar' });
+  });
+
+  test('try get json returns null if not json', () => {
+    expect(tryGetJson({o : 1})).toBe(null);
+  })
 });

--- a/server/utils/buildRestResponse.ts
+++ b/server/utils/buildRestResponse.ts
@@ -29,15 +29,33 @@ const buildRestResponse = async (searchResults: Result[], auth: any) => {
               .filter((k) => k.startsWith(field))
               .map((k) => k.replace(`${field}.`, ''));
 
-            const includedPopulatedData = {};
+            let includedPopulatedData;
 
             if (!fieldData) {
               continue;
             }
 
-            for (const fK of Object.keys(fieldData)) {
-              if (keysToInclude.includes(fK)) {
-                includedPopulatedData[fK] = fieldData[fK];
+            if (Array.isArray(fieldData)) {
+              includedPopulatedData = [];
+
+              for (const entry of fieldData) {
+                const includedEntry = {};
+
+                for (const fK of Object.keys(entry)) {
+                  if (keysToInclude.includes(fK)) {
+                    includedEntry[fK] = entry[fK];
+                  }
+                }
+
+                includedPopulatedData.push(includedEntry);
+              }
+            } else {
+              includedPopulatedData = {};
+
+              for (const fK of Object.keys(fieldData)) {
+                if (keysToInclude.includes(fK)) {
+                  includedPopulatedData[fK] = fieldData[fK];
+                }
               }
             }
 

--- a/server/utils/buildResult.ts
+++ b/server/utils/buildResult.ts
@@ -1,5 +1,6 @@
 import fuzzysort from 'fuzzysort';
 import { Entity, FilteredEntry } from '../interfaces/interfaces';
+import isJson from './isJSON';
 
 export default ({
   model,
@@ -34,7 +35,7 @@ export default ({
     });
   }
 
-  return {
+  const result = {
     pluralName: model.pluralName,
     schemaInfo: model.schemaInfo,
     uid: model.uid,
@@ -50,4 +51,16 @@ export default ({
         ),
     }),
   };
+
+  for (const entry of result.fuzzysortResults) {
+    for (const key of Object.keys(entry.obj)) {
+      const value = entry.obj[key];
+
+      if (isJson(value) && Array.isArray(JSON.parse(value))) {
+        entry.obj[key] = JSON.parse(value);
+      }
+    }
+  }
+
+  return result;
 };

--- a/server/utils/buildResult.ts
+++ b/server/utils/buildResult.ts
@@ -13,9 +13,29 @@ export default ({
 }) => {
   for (const entry of model[model.pluralName]) {
     for (const key of Object.keys(entry)) {
-      const value = entry[key];
+      let value = entry[key];
 
       if (Array.isArray(value)) {
+        const keyToSearchArray = keys.find((k) => k === key);
+
+        if (!keyToSearchArray) continue;
+
+        const isArrayOfObjects = value.every(
+          (v) => typeof v === 'object' && !!v
+        );
+
+        if (isArrayOfObjects) {
+          const keysToIncludeForArray = keys
+            .filter((k) => k.startsWith(`${key}.`))
+            .map((k) => k.replace(`${key}.`, ''));
+
+          value.map((v) => {
+            for (const k of Object.keys(v)) {
+              if (!keysToIncludeForArray.includes(k)) delete v[k];
+            }
+          });
+        }
+
         entry[key] = JSON.stringify(value);
       }
     }

--- a/server/utils/buildResult.ts
+++ b/server/utils/buildResult.ts
@@ -1,6 +1,6 @@
 import fuzzysort from 'fuzzysort';
 import { Entity, FilteredEntry } from '../interfaces/interfaces';
-import isJson from './isJSON';
+import { isJson, tryGetJson } from './isJSON';
 
 export default ({
   model,
@@ -76,8 +76,10 @@ export default ({
     for (const key of Object.keys(entry.obj)) {
       const value = entry.obj[key];
 
-      if (isJson(value) && Array.isArray(JSON.parse(value))) {
-        entry.obj[key] = JSON.parse(value);
+      const tryParse = tryGetJson(value);
+
+      if (tryParse && Array.isArray(tryParse)) {
+        entry.obj[key] = tryParse;
       }
     }
   }

--- a/server/utils/buildResult.ts
+++ b/server/utils/buildResult.ts
@@ -10,6 +10,16 @@ export default ({
   keys: string[];
   query: string;
 }) => {
+  for (const entry of model[model.pluralName]) {
+    for (const key of Object.keys(entry)) {
+      const value = entry[key];
+
+      if (Array.isArray(value)) {
+        entry[key] = JSON.stringify(value);
+      }
+    }
+  }
+
   if (model.fuzzysortOptions.characterLimit) {
     model[model.pluralName].forEach((entry) => {
       const entryKeys = Object.keys(entry);
@@ -23,7 +33,7 @@ export default ({
       });
     });
   }
-  
+
   return {
     pluralName: model.pluralName,
     schemaInfo: model.schemaInfo,

--- a/server/utils/getFilteredEntries.ts
+++ b/server/utils/getFilteredEntries.ts
@@ -19,7 +19,7 @@ const getFilteredEntries = async (locale: string, modelUid: string) => {
   const q = buildDbQuery(locale, modelUid);
 
   const res = await strapi.db.query(modelUid).findMany(q);
-
+  
   return res;
 };
 

--- a/server/utils/isJSON.ts
+++ b/server/utils/isJSON.ts
@@ -1,5 +1,8 @@
-function isJson(item) {
-  let value = typeof item !== 'string' ? JSON.stringify(item) : item;
+function isJson(item: any) {
+  if (typeof item !== 'string') return false;
+
+  let value = item;
+
   try {
     value = JSON.parse(value);
   } catch (e) {
@@ -9,4 +12,8 @@ function isJson(item) {
   return typeof value === 'object' && value !== null;
 }
 
-export default isJson;
+function tryGetJson(item: any) {
+  return isJson(item) ? JSON.parse(item) : null;
+}
+
+export { isJson, tryGetJson };

--- a/server/utils/isJSON.ts
+++ b/server/utils/isJSON.ts
@@ -1,0 +1,12 @@
+function isJson(item) {
+  let value = typeof item !== 'string' ? JSON.stringify(item) : item;
+  try {
+    value = JSON.parse(value);
+  } catch (e) {
+    return false;
+  }
+
+  return typeof value === 'object' && value !== null;
+}
+
+export default isJson;


### PR DESCRIPTION
Stringify nested arrays in buildResult to enable search
initial problem that original score function were built on a way, that it won’t look into nested array
it expects that object has only strings as values
so, i’ve stringied array, it will still look for matches, but don’t need to look for way around to calculate score for  nested arrays 
WON'T work with transliterations 
